### PR TITLE
fix: entrypoint fork checkout conflicting names

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ else
         # make new branch, locally
         git checkout -b "${localbranch}"
         # make a new local branch with our upstream data
-        git branch --set-upstream-to=origin/"$BASEBRANCH" "${GITHUB_HEAD_REF}"
+        git branch --set-upstream-to=origin/"$BASEBRANCH" "${localbranch}"
         git pull
 
         # populate a local base branch with upstream data


### PR DESCRIPTION
Continues work from b2eecca

We need to set the modified branch name to track the upstream unmodified branch name.